### PR TITLE
Docker changes and cloudbuild changes to support CD

### DIFF
--- a/consent-testing-service/DockerfileCD
+++ b/consent-testing-service/DockerfileCD
@@ -26,17 +26,13 @@ RUN echo "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\
 RUN mvn clean install -DskipTests -s settings.xml
 
 FROM openjdk:11-jdk
-ARG JAR_FILE=target/leap-ces-ccda-orchestration-0.0.1.war
+ARG JAR_FILE=target/consent-testing-service-0.0.1.war
 
 # Arguments declaration, needed to change ENV variables at build time
 ARG ARG_CDS_HOST_URL
-ARG ARG_SLS_HOST_URL
-ARG ARG_HAPI_FHIR_URL
 
 # Environment Variables declaration, needed to execute stand-alone Dockerfile with custom argumens if they are specified
 ENV CDS_HOST_URL=${ARG_CDS_HOST_URL}
-ENV SLS_HOST_URL=${ARG_SLS_HOST_URL}
-ENV HAPI_FHIR_URL=${ARG_HAPI_FHIR_URL}
 
-COPY --from=builder /leap-demos/leap-ces-ccda-orchestration/${JAR_FILE} app.jar
+COPY --from=builder /leap-demos/consent-testing-service/${JAR_FILE} app.jar
 ENTRYPOINT ["java", "-Dspring.profiles.active=docker", "-Dserver.tomcat.remote-ip-header=x-forwarded-for", "-Dserver.tomcat.protocol-header=x-forwarded-proto", "-jar", "/app.jar"]

--- a/consent-testing-service/DockerfileCD
+++ b/consent-testing-service/DockerfileCD
@@ -1,0 +1,42 @@
+FROM maven:3.6.3-jdk-11 as builder
+ARG GITHUB_USERNAME
+ARG GITHUB_PWD
+# Copy local code to the container image.
+WORKDIR leap-demos
+COPY leap-ces-ccda-orchestration leap-ces-ccda-orchestration
+COPY leap-ces-commons leap-ces-commons
+COPY leap-ces-fhir-client leap-ces-fhir-client
+COPY leap-ces-sls-client leap-ces-sls-client
+COPY leap-ces-v2-orchestration leap-ces-v2-orchestration
+COPY consent-testing-service consent-testing-service
+COPY pom.xml pom.xml
+RUN echo "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\
+          <settings xsi:schemaLocation=\"http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd\" xmlns=\"http://maven.apache.org/SETTINGS/1.0.0\"\
+          		  xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\
+             <servers>\
+             	<server>\
+                		<id>github</id>\
+                		<username>${GITHUB_USERNAME}</username>\
+          	      	<password>${GITHUB_PWD}</password>\
+              	</server>\
+             </servers>\
+             <offline>false</offline>\
+          </settings>" > settings.xml
+# Build a release artifact.
+RUN mvn clean install -DskipTests -s settings.xml
+
+FROM openjdk:11-jdk
+ARG JAR_FILE=target/leap-ces-ccda-orchestration-0.0.1.war
+
+# Arguments declaration, needed to change ENV variables at build time
+ARG ARG_CDS_HOST_URL
+ARG ARG_SLS_HOST_URL
+ARG ARG_HAPI_FHIR_URL
+
+# Environment Variables declaration, needed to execute stand-alone Dockerfile with custom argumens if they are specified
+ENV CDS_HOST_URL=${ARG_CDS_HOST_URL}
+ENV SLS_HOST_URL=${ARG_SLS_HOST_URL}
+ENV HAPI_FHIR_URL=${ARG_HAPI_FHIR_URL}
+
+COPY --from=builder /leap-demos/leap-ces-ccda-orchestration/${JAR_FILE} app.jar
+ENTRYPOINT ["java", "-Dspring.profiles.active=docker", "-Dserver.tomcat.remote-ip-header=x-forwarded-for", "-Dserver.tomcat.protocol-header=x-forwarded-proto", "-jar", "/app.jar"]

--- a/consent-testing-service/cloudbuild.yaml
+++ b/consent-testing-service/cloudbuild.yaml
@@ -1,0 +1,35 @@
+steps:
+  # Build the container image
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build',
+           '--build-arg',
+           'ARG_SLS_HOST_URL=${_SLS_HOST_URL}',
+           '--build-arg',
+           'ARG_CDS_HOST_URL=${_CDS_HOST_URL}',
+           '--build-arg',
+           'ARG_HAPI_FHIR_URL=${_HAPI_FHIR_URL}',
+           '--build-arg',
+           'GITHUB_USERNAME=${_GITHUB_USERNAME}',
+           '--build-arg',
+           'GITHUB_PWD=${_GITHUB_PWD}',
+           '-t',
+           'gcr.io/${_SERVICE_NAME}/github.com/sdhealthconnect/leap-demos:$COMMIT_SHA',
+           '-f',
+           'leap-ces-ccda-orchestration/DockerfileCD', # Change this line according the proiject to build
+           '.']
+  # Push the container image to Container Registry
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['push', 'gcr.io/${_SERVICE_NAME}/github.com/sdhealthconnect/leap-demos:$COMMIT_SHA']
+  # Deploy container image to Cloud Run
+  - name: 'gcr.io/cloud-builders/gcloud'
+    args: ['run',
+           'deploy',
+           '${_SERVICE_NAME}',
+           '--image',
+           'gcr.io/${_SERVICE_NAME}/github.com/sdhealthconnect/leap-demos:$COMMIT_SHA',
+           '--region',
+           'us-central1',
+           '--platform',
+           'managed']
+images:
+  - 'gcr.io/${_SERVICE_NAME}/github.com/sdhealthconnect/leap-demos:$COMMIT_SHA'

--- a/consent-testing-service/cloudbuild.yaml
+++ b/consent-testing-service/cloudbuild.yaml
@@ -3,11 +3,7 @@ steps:
   - name: 'gcr.io/cloud-builders/docker'
     args: ['build',
            '--build-arg',
-           'ARG_SLS_HOST_URL=${_SLS_HOST_URL}',
-           '--build-arg',
            'ARG_CDS_HOST_URL=${_CDS_HOST_URL}',
-           '--build-arg',
-           'ARG_HAPI_FHIR_URL=${_HAPI_FHIR_URL}',
            '--build-arg',
            'GITHUB_USERNAME=${_GITHUB_USERNAME}',
            '--build-arg',
@@ -15,7 +11,7 @@ steps:
            '-t',
            'gcr.io/${_SERVICE_NAME}/github.com/sdhealthconnect/leap-demos:$COMMIT_SHA',
            '-f',
-           'leap-ces-ccda-orchestration/DockerfileCD', # Change this line according the proiject to build
+           'consent-testing-service/DockerfileCD', # Change this line according the project to build
            '.']
   # Push the container image to Container Registry
   - name: 'gcr.io/cloud-builders/docker'


### PR DESCRIPTION
In order to support these changes we need to link the https://github.com/sdhealthconnect/leap-demos/tree/master/consent-testing-service repository within this trigger in gcloud platform:  https://console.cloud.google.com/cloud-build/triggers/add?project=sdhc-leap-consent-testing