### PR TITLE
FHIR AuditEvent Calls Moved to CDS

### DIFF
--- a/consent-testing-service/Dockerfile
+++ b/consent-testing-service/Dockerfile
@@ -1,12 +1,5 @@
 FROM openjdk:11-jdk
 
 ARG JAR_FILE=target/consent-testing-service-0.0.1.war
-
-# Arguments declaration, needed to change ENV variables at build time
-ARG ARG_CDS_HOST_URL
-
-# Environment Variables declaration, needed to execute stand-alone Dockerfile with custom argumens if they are specified
-ENV CDS_HOST_URL=${ARG_CDS_HOST_URL}
-
 COPY ${JAR_FILE} app.jar
-ENTRYPOINT ["java", "-Dspring.profiles.active=docker", "-jar", "/app.jar"]
+ENTRYPOINT ["java","-Dspring.profiles.active=docker","-jar","/app.jar"]

--- a/consent-testing-service/docker-push.sh
+++ b/consent-testing-service/docker-push.sh
@@ -1,3 +1,3 @@
 docker login docker.io
-docker tag 6de670d0be4c ddecouteau/consent-testing-service
+docker tag sha256:91d8143a745555d8343ac4512255b80b38fab358a295064834b5aad58e71949a ddecouteau/consent-testing-service
 docker push ddecouteau/consent-testing-service

--- a/consent-testing-service/pom.xml
+++ b/consent-testing-service/pom.xml
@@ -21,16 +21,7 @@
 
     <dependency>
         <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-data-rest</artifactId>
-    </dependency>
-    <dependency>
-        <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-web</artifactId>
-    </dependency>
-    <dependency>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-starter-tomcat</artifactId>
-        <scope>provided</scope>
     </dependency>
     <dependency>
         <groupId>org.springframework.boot</groupId>
@@ -54,17 +45,18 @@
     <dependency>
         <groupId>gov.hhs.onc.leap</groupId>
         <artifactId>leap-ces-clients</artifactId>
-        <version>0.2.0</version>
+        <version>0.3.0</version>
     </dependency>
     <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-test</artifactId>
         <scope>test</scope>
-    </dependency>
-    <dependency>
-        <groupId>gov.hhs.onc.leap</groupId>
-        <artifactId>leap-ces-fhir-client</artifactId>
-        <version>0.0.1</version>
+        <exclusions>
+            <exclusion>
+                <groupId>org.junit.vintage</groupId>
+                <artifactId>junit-vintage-engine</artifactId>
+            </exclusion>
+        </exclusions>
     </dependency>
     <dependency>
         <groupId>io.swagger.core.v3</groupId>

--- a/consent-testing-service/src/main/java/gov/hhs/onc/leap/fhir/connectathon/consent/controller/FHIRConnectathonController.java
+++ b/consent-testing-service/src/main/java/gov/hhs/onc/leap/fhir/connectathon/consent/controller/FHIRConnectathonController.java
@@ -26,8 +26,8 @@ public class FHIRConnectathonController {
     @Operation(summary = "Authorization Request",
             description = "Request Authorization Decision from LEAP CDS",
             responses = {
-                    @ApiResponse(responseCode = "200", description = "Authorization of Permit Recieved - Processing of Message is proceeding"),
-                    @ApiResponse(responseCode = "404", description = "Authorization of Deny Recieved - Processing of Message has ended")})
+                    @ApiResponse(responseCode = "200", description = "Authorization of Permit Received - Processing of Message is proceeding"),
+                    @ApiResponse(responseCode = "404", description = "Authorization of Deny Received - Processing of Message has ended")})
     @PostMapping(path = "/authRequest",
             consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE, MediaType.TEXT_PLAIN_VALUE},
             produces = {MediaType.TEXT_PLAIN_VALUE})

--- a/consent-testing-service/src/main/java/gov/hhs/onc/leap/fhir/connectathon/consent/service/FHIRConnectathonService.java
+++ b/consent-testing-service/src/main/java/gov/hhs/onc/leap/fhir/connectathon/consent/service/FHIRConnectathonService.java
@@ -7,16 +7,12 @@ import gov.hhs.onc.leap.ces.common.clients.model.card.PatientConsentConsultHookR
 import gov.hhs.onc.leap.ces.common.clients.model.xacml.XacmlRequest;
 import gov.hhs.onc.leap.ces.common.clients.model.xacml.XacmlResponse;
 import gov.hhs.onc.leap.ces.common.clients.xacml.ConsentConsultXacmlClient;
-import gov.hhs.onc.leap.ces.fhir.client.utils.FHIRAudit;
-import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component
-@Slf4j
 public class FHIRConnectathonService {
     private static final Logger log = LoggerFactory.getLogger(FHIRConnectathonService.class);
     @Value("${cds.host.url}")
@@ -25,8 +21,6 @@ public class FHIRConnectathonService {
     private ConsentConsultCardClient cardClient;
     private ConsentConsultXacmlClient xacmlClient;
     private String msg;
-
-    private FHIRAudit fhirAudit = new FHIRAudit();
 
     public String authRequest(String msg) {
 
@@ -53,13 +47,13 @@ public class FHIRConnectathonService {
             PatientConsentConsultHookRequest cardRequest = mapper.readValue(msg, PatientConsentConsultHookRequest.class);
             cardClient = new ConsentConsultCardClient(CDS_HOST);
             PatientConsentConsultHookResponse cardResponse = cardClient.getConsentDecision(cardRequest);
-            fhirAudit.auditConsentDecision(cardRequest, cardResponse);
             res = mapper.writeValueAsString(cardResponse);
         }
         catch (Exception ex) {
             log.error(ex.getMessage());
             res = res + ex.getMessage();
         }
+        System.out.println("PROCESS CDS HOOKS RESPONSE "+ res);
         return res;
     }
 
@@ -70,13 +64,13 @@ public class FHIRConnectathonService {
             XacmlRequest request = mapper.readValue(msg, XacmlRequest.class);
             xacmlClient = new ConsentConsultXacmlClient(CDS_HOST);
             XacmlResponse response = xacmlClient.getConsentDecision(request);
-            fhirAudit.auditConsentDecision(request, response);
             res = mapper.writeValueAsString(response);
         }
         catch (Exception ex) {
             log.error(ex.getMessage());
             res = res + ex.getMessage();
         }
+        System.out.println("PROCESS XACML RESPONSE "+res);
         return res;
     }
 


### PR DESCRIPTION
Remove calls to log event in FHIR AuditEvent which is now handled by CDS
Clean up of pom.
updates version leap-ces-clients to 0.3.0

This image has been built and deployed to Docker hub and our alternate gcp for FHIR Connectathon